### PR TITLE
Remove consul variables that interfere with consul_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ### Removed
 ### Fixed
 
+## [1.0.2](https://github.com/idealista/patroni_role/tree/1.0.2) (2024-07-03)
+### [Full Changelog](https://github.com/idealista/patroni_role/compare/1.0.1...1.0.2)
+### Changed
+- *[#8](https://github.com/idealista/patroni_role/issues/8) Remove consul variables that interfere with consul_role* @ledepedro
+
 ## [1.0.1](https://github.com/idealista/patroni_role/tree/1.0.1) (2024-06-20)
 ### [Full Changelog](https://github.com/idealista/patroni_role/compare/1.0.0...1.0.1)
 ### Changed

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -82,33 +82,6 @@ patroni_etcd_protocol: ""             # (optional) http or https, if not specifi
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#etcd
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#consul
 
-# if dcs_type: "consul"
-consul_version: "1.2.3"
-consul_config_path: "/etc/consul"
-consul_configd_path: "{{ consul_config_path }}/conf.d"
-consul_data_path: "/var/lib/consul"
-consul_domain: "consul"  # Consul domain name
-consul_datacenter: "mainlocal"  # Datacenter label (can be specified for each host in the inventory)
-consul_disable_update_check: true  # Disables automatic checking for security bulletins and new version releases
-consul_enable_script_checks: true  # This controls whether health checks that execute scripts are enabled on this agent
-consul_enable_local_script_checks: true  # Enable them when they are defined in the local configuration files
-consul_ui: false  # Enable the consul UI?
-consul_syslog_enable: true  # Enable logging to syslog
-consul_iface: "{{ ansible_default_ipv4.interface }}"  # specify the interface name with a Private IP (ex. "enp7s0")
-# TLS
-# You can enable TLS encryption by dropping a CA certificate, server certificate, and server key in roles/consul/files/
-consul_tls_enable: false
-consul_tls_ca_crt: "ca.crt"
-consul_tls_server_crt: "server.crt"
-consul_tls_server_key: "server.key"
-# DNS
-consul_recursors: []  # List of upstream DNS servers
-consul_dnsmasq_enable: true  # Enable DNS forwarding with Dnsmasq
-consul_dnsmasq_cache: 0  # dnsmasq cache-size (0 - disable caching)
-consul_dnsmasq_servers:  # Upstream DNS servers used by dnsmasq
-  - "8.8.8.8"
-  - "9.9.9.9"
-
 patroni_consul_host: "{{ patroni.consul_host | default ('127.0.0.1:8500') }}"
 patroni_consul_register_service: "{{ patroni.consul_register_service | default (false) }}"
 patroni_consul_checks: "{{ patroni.consul_checks | default ([]) }}"


### PR DESCRIPTION
### Description of the Change

Remove consul variables that are not used within the role and that interfere with consul_role.

### Benefits

The value of "datacenter" in /opt/consul/consul.d is the value defined in the variable datacenter.
